### PR TITLE
Adding try/catch around date converters which can fail

### DIFF
--- a/src/converters/roam/index.ts
+++ b/src/converters/roam/index.ts
@@ -527,8 +527,10 @@ export class RoamConverter implements IConverter {
       if (link?.match(DATE_REGEX)) {
         const dateUid = dateStringToYMD(link);
 
-        nodeForImport.name = nodeForImport.name.replace(link, 'date:' + dateUid);
-        continue;
+        if (dateUid) {
+          nodeForImport.name = nodeForImport.name.replace(link, 'date:' + dateUid);
+          continue;
+        }
       }
       if (nodeForImport.children?.some((c) => c.name === link || c.uid === link)) {
         continue;

--- a/src/converters/roam/roamUtils.ts
+++ b/src/converters/roam/roamUtils.ts
@@ -53,22 +53,30 @@ const months = [
 
 // Convert 'June 1st, 2021' to '06-01-2021' without dealing with timezones etc
 export function dateStringToRoamDateUID(str: string) {
-  str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
-  const pieces = str.split(' ');
-  const month = months.indexOf(pieces[0]) + 1;
-  return `${month.toString().padStart(2, '0')}-${pieces[1].toString().padStart(2, '0')}-${pieces[2]
-    .toString()
-    .padStart(4, '0')}`;
+  try {
+    str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
+    const pieces = str.split(/ /);
+    const month = months.indexOf(pieces[0]) + 1;
+    return `${month.toString().padStart(2, '0')}-${pieces[1].toString().padStart(2, '0')}-${pieces[2]
+      .toString()
+      .padStart(4, '0')}`;
+  } catch (e) {
+    console.warn(str, e);
+  }
 }
 
 // Convert 'June 1st, 2021' to 'YYYY-MM-DD' without dealing with timezones etc
 export function dateStringToYMD(str: string) {
-  str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
-  const pieces = str.split(' ');
-  const month = months.indexOf(pieces[0]) + 1;
-  return `${pieces[2].toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${pieces[1]
-    .toString()
-    .padStart(2, '0')}`;
+  try {
+    str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
+    const pieces = str.split(' ');
+    const month = months.indexOf(pieces[0]) + 1;
+    return `${pieces[2].toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${pieces[1]
+      .toString()
+      .padStart(2, '0')}`;
+  } catch (e) {
+    console.warn(str, e);
+  }
 }
 
 export function getValueForAttribute(fieldName: string, node: string): string | undefined {


### PR DESCRIPTION
I have seen examples of Roam files with date-like titles that cause the converter to fail. Two examples:

July19th,2020 (no spaces)

Another example where it looked fine, but somehow the spaces were not a space character but some other whitespace character (when I replaced `split(' ')` with `split(/\s/)` it worked). Since there is no telling what we will encounter, I propose just putting a try...catch around these two functions, and if it doesn't work, we just leave them as normal nodes. 