### PR TITLE
Allow for weird spaces in day node titles

### DIFF
--- a/src/converters/common.test.ts
+++ b/src/converters/common.test.ts
@@ -29,11 +29,13 @@ test('getValueForAttribute', () => {
 test('dateStringToUSDateUID', () => {
   expect(dateStringToUSDateUID('June 1st, 2021')).toBe('06-01-2021');
   expect(dateStringToUSDateUID('August 14th, 2021')).toBe('08-14-2021');
+  expect(dateStringToYMD('February 13th, 2023')).toBe('2023-02-13');
 });
 
 test('dateStringToYMD', () => {
   expect(dateStringToYMD('June 1st, 2021')).toBe('2021-06-01');
   expect(dateStringToYMD('August 14th, 2021')).toBe('2021-08-14');
+  expect(dateStringToYMD('February 13th, 2023')).toBe('2023-02-13');
 });
 
 test('hasImages', () => {

--- a/src/converters/common.ts
+++ b/src/converters/common.ts
@@ -21,22 +21,22 @@ const months = [
   'December',
 ];
 
-const monthPrefixes = months.map((m) => m.slice(0, 3))
+const monthPrefixes = months.map((m) => m.slice(0, 3));
 
 // Convert 'June 1st, 2021' and 'Jun 1st, 2021' to 'MM-DD-YYYY' without dealing with timezones, etc.
 export function dateStringToUSDateUID(str: string) {
   str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
-  const pieces = str.split(' ');
+  const pieces = str.split(/\s/);
 
   const monthMatch = months.indexOf(pieces[0]);
   const monthPrefixMatch = monthPrefixes.indexOf(pieces[0]);
-  let month
+  let month;
   if (monthMatch !== -1) {
-    month = monthMatch + 1
+    month = monthMatch + 1;
   } else if (monthPrefixMatch !== -1) {
-    month = monthPrefixMatch + 1
+    month = monthPrefixMatch + 1;
   } else {
-    return str
+    return str;
   }
 
   return `${month.toString().padStart(2, '0')}-${pieces[1].toString().padStart(2, '0')}-${pieces[2]
@@ -47,7 +47,7 @@ export function dateStringToUSDateUID(str: string) {
 // Convert 'June 1st, 2021' to 'YYYY-MM-DD' without dealing with timezones etc
 export function dateStringToYMD(str: string) {
   str = str.replace(/(^\w+\s\d{1,2})(\w{2}),(\s\d+)/, '$1$3');
-  const pieces = str.split(' ');
+  const pieces = str.split(/\s/);
   const month = months.indexOf(pieces[0]) + 1;
   return `${pieces[2].toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${pieces[1]
     .toString()


### PR DESCRIPTION
I had a Roam file that failed because it somehow had a day node title with a different space... Not sure how this happened, but apparently Roam allows it, and this change makes our date parsing code a bit more robust to this case. Added test as well.