### PR TITLE
Update fields.tif.json

### DIFF
--- a/samples/tif/fields.tif.json
+++ b/samples/tif/fields.tif.json
@@ -2,8 +2,13 @@
   "version": "TanaIntermediateFile V0.1",
   "attributes": [
     {
-      "name": "Owner",
+      "name": "Holder",
+      "_comment1": "the field will be ignored by Tana's TIF importer unless its name is included in the attributes array",
+      "values": [
+        "Jack"
+      ],
       "count": 1
+      "_comment2": "Tana's TIF importer will handle fields just fine without 'values' or 'count'" keys,
     }
   ],
 
@@ -15,20 +20,15 @@
     },
     {
       "name": "Holder",
-      "type": "node",
       "children": [
         {
-          "name": "Owner",
-          "children": [
-            {
-              "name": "[[jackId]]",
-              "refs": ["jackId"],
-              "type": "node"
-            }
-          ],
-          "type": "field"
+          "uid": "holderId",
+          "name": "[[jackId]]",
+          "refs": ["jackId"],
+          "type": "node"
         }
-      ]
+      ],
+      "type": "field"
     }
   ]
 }

--- a/samples/tif/fields.tif.json
+++ b/samples/tif/fields.tif.json
@@ -7,8 +7,8 @@
       "values": [
         "Jack"
       ],
-      "count": 1
-      "_comment2": "Tana's TIF importer will handle fields just fine without 'values' or 'count'" keys,
+      "count": 1,
+      "_comment2": "Tana's TIF importer will handle fields just fine without 'values' or 'count' keys"
     }
   ],
 


### PR DESCRIPTION
The existing sample, if imported to Tana, generates an infinite chain of nested children without any actual fields.

My proposed version fixes the infinite regress, generates actual fields if imported into Tana, and (most importantly) gives guidance to people who are looking to import fields into Tana but are puzzled by the how to use the attributes array (which has zero documentation in tana-import-tools).