### PR TITLE
Logseq: Fix refs on arbitrary text

### DIFF
--- a/src/converters/logseq/index.ts
+++ b/src/converters/logseq/index.ts
@@ -552,9 +552,6 @@ export class LogseqConverter implements IConverter {
         nodeForImport.refs.push(refNode.uid);
         continue;
       }
-      if (link === 'roam/js' || link === 'roam/css' || link === '{{[[roam/js]]}}') {
-        continue;
-      }
 
       // Still not found, so we create it in stash.
       refNode = this.createNodeForImport({

--- a/src/converters/logseq/tests/fixtures/block_refs.json
+++ b/src/converters/logseq/tests/fixtures/block_refs.json
@@ -37,6 +37,12 @@
           "format": "markdown",
           "children": [],
           "content": "See ((child2))"
+        },
+        {
+          "id": "child4",
+          "format": "markdown",
+          "children": [],
+          "content": "inline [block reference](((child2))) on arbitrary text"
         }
       ]
     }

--- a/src/converters/logseq/tests/logseq.test.ts
+++ b/src/converters/logseq/tests/logseq.test.ts
@@ -41,13 +41,16 @@ test('Block references', () => {
   const [file, f] = importLogseqFile('block_refs.json');
 
   expect(file.summary.topLevelNodes).toEqual(3);
-  expect(file.summary.totalNodes).toEqual(6);
+  expect(file.summary.totalNodes).toEqual(7);
   const child2 = f('page2')?.children?.[0];
   expect(child2?.name).toEqual('[[child1]]');
   expect(child2?.refs).toEqual(['child1']);
   const child3 = f('page3')?.children?.[0];
   expect(child3?.name).toEqual('See [[child2]]');
   expect(child3?.refs).toEqual(['child2']);
+  const child4 = f('page3')?.children?.[1];
+  expect(child4?.name).toEqual('inline [block reference]([[child2]]) on arbitrary text');
+  expect(child4?.refs).toEqual(['child2']);
 });
 
 test('Codeblocks', () => {

--- a/src/converters/roam/index.ts
+++ b/src/converters/roam/index.ts
@@ -6,7 +6,7 @@ import {
   TanaIntermediateSummary,
 } from '../../types/types.js';
 import {
-  enrichRoam,
+  markdownToHTML,
   findGroups,
   getBracketLinks,
   getCodeIfCodeblock,
@@ -82,7 +82,7 @@ export class RoamConverter implements IConverter {
           // normalize the links
           this.normalizeLinksAndSetAliases(nodeForImport);
 
-          nodeForImport.name = enrichRoam(nodeForImport.name);
+          nodeForImport.name = markdownToHTML(nodeForImport.name);
         }
       }
     } catch (error) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -111,7 +111,7 @@ export function getBracketLinks(text: string, skipIfNotDirect: boolean): string[
 }
 
 // Note: This is a very rudimentary enrichment. We should move to markdown at some point
-export function enrichRoam(nodeContent: string) {
+export function markdownToHTML(nodeContent: string) {
   if (!nodeContent) {
     return nodeContent;
   }


### PR DESCRIPTION
Fixes parsing references with arbitrary text like this: `[arbitrary text](((6750c674-ff0e-4b16-baa1-41a476cdc7b7)))`
Issue by Rick K via slack:

> First, the Logseq importer tool breaks all references to blocks, as they are called in Logseq. In Tana everything is a node. In Logseq, there are pages (root-level nodes) and blocks (nodes). The importer tool handles references to pages perfectly. But because Logseq exports references to blocks with the uuid surrounded by triple parentheses, the Tana importer doesn't recognize them as references, and imports them as simple text (a uuid surrounded by three parentheses)