### PR TITLE
Add support for viewTypes

### DIFF
--- a/src/converters/markdown/index.ts
+++ b/src/converters/markdown/index.ts
@@ -514,6 +514,7 @@ export class MarkdownConverter implements IConverter {
         editedAt: Date.now(),
         type: 'node',
       });
+      tableWrapper.viewType = 'table';
       tableWrapper.children = [];
       parent.children.push(tableWrapper);
       this.summary.totalNodes += 1;
@@ -900,6 +901,7 @@ export class MarkdownConverter implements IConverter {
             editedAt: Date.now(),
             type: 'node',
           });
+          tableWrapper.viewType = 'table';
           tableWrapper.children = [];
           parent.children.push(tableWrapper);
           this.summary.totalNodes += 1;

--- a/src/converters/markdown/tests/markdown.test.ts
+++ b/src/converters/markdown/tests/markdown.test.ts
@@ -223,6 +223,7 @@ test('Links to other pages and files', () => {
   expect(csvWrapper, 'Expected CSV table wrapper under page A').toBeDefined();
   const csvUid = csvWrapper!.uid;
   expect(csvWrapper!.name).toBe('CSV');
+  expect(csvWrapper!.viewType).toBe('table');
 
   const findChildByPrefix = (prefix: string) =>
     (pageA?.children || []).find((child: any) => typeof child.name === 'string' && child.name.startsWith(prefix));
@@ -274,6 +275,7 @@ test('Links to other pages and external files', () => {
   expect(csvWrapper).toBeDefined();
   const csvUid = csvWrapper!.uid;
   expect(csvWrapper!.name).toBe('CSV');
+  expect(csvWrapper!.viewType).toBe('table');
 
   const findChildByPrefix = (prefix: string) =>
     (pageA?.children || []).find((child: any) => typeof child.name === 'string' && child.name.startsWith(prefix));
@@ -306,6 +308,7 @@ test('CSV links without alias use Table fallback name', () => {
   );
   expect(tableWrapper, 'Expected CSV table wrapper created from unnamed link').toBeDefined();
   expect(tableWrapper!.name).toBe('Table');
+  expect(tableWrapper!.viewType).toBe('table');
 });
 
 test('Duplicate names under root become references to root nodes', () => {
@@ -482,6 +485,10 @@ test('Converts tables', () => {
   const containerNode = findByName(page, 'People');
   expect(containerNode).toBeDefined();
 
+  const tableWrapper = (containerNode?.children || []).find((child) => child.viewType === 'table');
+  expect(tableWrapper, 'Expected table wrapper for People table').toBeDefined();
+  expect(tableWrapper!.viewType).toBe('table');
+
   // Should have rows named by the first column
   const aliceRow = findByName(containerNode!, 'Alice');
   const bobRow = findByName(containerNode!, 'Bob');
@@ -522,6 +529,7 @@ test('Empty tables produce a single wrapper with empty rows, not repeated tables
   expect(wrappers.length).toBe(1);
 
   const wrapper = wrappers[0];
+  expect(wrapper.viewType).toBe('table');
   // It should have exactly 5 row nodes (one per empty row)
   const rows = wrapper.children || [];
   expect(rows.length).toBe(5);
@@ -547,6 +555,7 @@ test('Standalone CSV link is converted into a table', () => {
       ),
   );
   expect(roadMapWrapper, 'Expected Road map CSV wrapper under indyRIOT').toBeDefined();
+  expect(roadMapWrapper!.viewType).toBe('table');
 
   expect(roadMapWrapper!.name).toBe('Road map database with views');
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -55,6 +55,8 @@ export type NodeType = 'field' | 'image' | 'codeblock' | 'node' | 'date';
 
 export type FlagType = 'section';
 
+export type ViewType = 'list' | 'table';
+
 export type TanaIntermediateNode = {
   // uid of the node, only used during import. There is no mapping to the Tana Node id
   uid: string;
@@ -101,6 +103,8 @@ export type TanaIntermediateNode = {
 
   // for section/heading nodes
   flags?: FlagType[];
+
+  viewType?: ViewType;
 
   // if set, we will create TODO / DONE for this node
   todoState?: 'todo' | 'done';


### PR DESCRIPTION
- Adds support for setting `viewType`
- Sets `viewType` to `table` for Markown/CSV parsed tables